### PR TITLE
Update navbar labels and plugin links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -114,13 +114,13 @@ const config: Config = {
     navbar: {
       title: 'BrainDrive',
       items: [
-        { to: '/core/OWNER_USER_GUIDE', label: 'System Overview', position: 'left' },
+        { to: '/core/OWNER_USER_GUIDE', label: "Owner's Manual", position: 'left' },
         { to: '/core/INSTALL', label: 'Install', position: 'left' },
-        { to: '/plugins/intro', label: 'Plugins', position: 'left' },
         {
           label: 'Plugin Development',
           position: 'left',
           items: [
+            { to: '/plugins/intro', label: 'Plugins Overview' },
             { to: '/core/PLUGIN_DEVELOPER_QUICKSTART', label: 'Dev Quickstart' },
             { to: '/template/intro', label: 'Plugin Template' },
             { to: '/services/intro', label: 'Service Bridges' },


### PR DESCRIPTION
## Summary
- rename the System Overview navigation item to Owner's Manual
- nest the plugins documentation link under Plugin Development and retitle it Plugins Overview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c1a22e3c8320b780d9659c5c6684